### PR TITLE
Fix duplicate tokens bug

### DIFF
--- a/app/Observers/TokenObserver.php
+++ b/app/Observers/TokenObserver.php
@@ -30,7 +30,7 @@ class TokenObserver
      */
     private function deleteUserTokens($userId)
     {
-        Token::where('user_id', $userId)->delete();
+        Token::withoutGlobalScopes()->where('user_id', $userId)->delete();
     }
 
     /**

--- a/tests/Unit/DuplicateTokenTest.php
+++ b/tests/Unit/DuplicateTokenTest.php
@@ -5,6 +5,8 @@ namespace Tests\Unit;
 use App\Models\Token;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
 
 class DuplicateTokenTest extends TestCase
@@ -12,7 +14,7 @@ class DuplicateTokenTest extends TestCase
     use RefreshDatabase;
 
     /** @test */
-    public function creating_a_new_user_token_deletes_existing_user_tokens()
+    public function creating_a_token_deletes_active_user_tokens()
     {
         $user = factory(User::class)->create();
         $token = factory(Token::class)->create(['user_id' => $user->id]);
@@ -23,7 +25,31 @@ class DuplicateTokenTest extends TestCase
 
         $this->assertDatabaseMissing('tokens', [
             'password' => $token->password,
-            'user_id' => $user->id
+            'user_id'  => $user->id,
+        ]);
+    }
+
+    /** @test */
+    public function creating_a_token_deletes_expired_user_tokens()
+    {
+        $user = factory(User::class)->create();
+
+        // We have to manually create the token for this test.
+        DB::table('tokens')->insert([
+            'user_id'    => $user->id,
+            'created_at' => Carbon::now()->subMinutes(20),
+            'expires_at' => Carbon::now()->subMinutes(5),
+            'password'   => 'abc123',
+            'updated_at' => Carbon::now()->subMinutes(20),
+        ]);
+
+        Token::create(['user_id' => $user->id]);
+
+        $this->assertDatabaseHas('tokens', ['user_id' => $user->id]);
+
+        $this->assertDatabaseMissing('tokens', [
+            'password' => 'abc123',
+            'user_id'  => $user->id,
         ]);
     }
 }


### PR DESCRIPTION
Fix a bug whereby expired tokens are not deleted from the database, prior to creating a new user token, due to the default token global scope.

As a result, a duplicate record DB exception is thrown.

Closes #31.