### PR TITLE
Handle empty bylines

### DIFF
--- a/app/News/Transformers/NewsApi.php
+++ b/app/News/Transformers/NewsApi.php
@@ -17,7 +17,7 @@ class NewsApi implements Transformer
             ->map(function ($item, $index) {
                 return [
                     'abstract'    => $item->description,
-                    'byline'      => $item->author,
+                    'byline'      => $item->author ?: $item->source->name,
                     'external_id' => $item->url,
                     'popularity'  => $index + 1,
                     'title'       => $item->title,

--- a/tests/Unit/News/Transformers/NewsApiTest.php
+++ b/tests/Unit/News/Transformers/NewsApiTest.php
@@ -58,6 +58,17 @@ class NewsApiTest extends TestCase
     }
 
     /** @test */
+    public function it_uses_the_news_source_if_the_byline_is_empty()
+    {
+        $input = $this->getInput();
+        $input[0]->author = '';
+
+        $transformed = (new NewsApi)->transform($input);
+
+        $this->assertEquals($input[0]->source->name, $transformed[0]['byline']);
+    }
+
+    /** @test */
     public function it_uses_the_url_as_the_external_id()
     {
         $transformed = (new NewsApi)->transform($this->getInput());


### PR DESCRIPTION
Use the news source as the byline, if no byline is provided.

Closes #33.